### PR TITLE
fix(auth): #22827 missing region error when using AWS credentials file auth

### DIFF
--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -123,6 +123,15 @@ pub enum AwsAuthentication {
         #[configurable(metadata(docs::examples = "develop"))]
         #[serde(default = "default_profile")]
         profile: String,
+
+        /// The [AWS region][aws_region] to send STS requests to.
+        ///
+        /// If not set, this defaults to the configured region
+        /// for the service itself.
+        ///
+        /// [aws_region]: https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints
+        #[configurable(metadata(docs::examples = "us-west-2"))]
+        region: Option<String>,
     },
 
     /// Assume the given role ARN.
@@ -297,6 +306,7 @@ impl AwsAuthentication {
             AwsAuthentication::File {
                 credentials_file,
                 profile,
+                region,
             } => {
                 let connector = super::connector(proxy, tls_options)?;
 
@@ -306,7 +316,10 @@ impl AwsAuthentication {
                     .with_file(ProfileFileKind::Credentials, credentials_file)
                     .build();
 
-                let provider_config = ProviderConfig::empty().with_http_client(connector);
+                let auth_region = region.clone().map(Region::new).unwrap_or(service_region);
+                let provider_config = ProviderConfig::empty()
+                    .with_region(Option::from(auth_region))
+                    .with_http_client(connector);
 
                 let profile_provider = ProfileFileCredentialsProvider::builder()
                     .profile_files(profile_files)
@@ -690,6 +703,7 @@ mod tests {
             r#"
             auth.credentials_file = "/path/to/file"
             auth.profile = "foo"
+            auth.region = "us-west-2"
         "#,
         )
         .unwrap();
@@ -698,9 +712,11 @@ mod tests {
             AwsAuthentication::File {
                 credentials_file,
                 profile,
+                region,
             } => {
                 assert_eq!(&credentials_file, "/path/to/file");
                 assert_eq!(&profile, "foo");
+                assert_eq!(region.unwrap(), "us-west-2");
             }
             _ => panic!(),
         }
@@ -716,6 +732,7 @@ mod tests {
             AwsAuthentication::File {
                 credentials_file,
                 profile,
+                ..
             } => {
                 assert_eq!(&credentials_file, "/path/to/file");
                 assert_eq!(profile, "default".to_string());


### PR DESCRIPTION
## Summary
Resolves newly created bug #22827, adding `region` to the credentials_file authentication method for aws services.   

Before this fix, when using `auth.credentials_file`, and the file contained `role_arn`, and `web_identity_token` keys, the resulting sts calls produced a "Invalid Configuration" error in the log, and prevented the cloudwatch logs sink from authenticating.    This fix adds 'auth.region' to the valid spec, and sets the value to the `service_region` if not provided.

## Change Type
- [X] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## How did you test this PR?
```
[sinks.output_my_cw]
type = "aws_cloudwatch_logs"
inputs = ["in"]
region = "us-east-2"
group_name = "group-test"
stream_name = "my-stream"
auth.credentials_file = "/root/.aws/credentials"
#auth.profile = "default"
encoding.codec = "json"

--------------------------
#Sample aws credentials file:
[default]
web_identity_token_file=/var/run/secrets/serviceaccount/token
role_arn=arn:aws:iam::123456789012:role/logging-role-for-sts
```

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [X] No. A maintainer will apply the "no-changelog" label to this PR.

## Checklist
- [X] Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- [X] If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `dd-rust-license-tool write` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).

## References
- Closes: https://github.com/vectordotdev/vector/issues/22827

